### PR TITLE
Fixes bug where colormaps would be unordered

### DIFF
--- a/metaseq/colormap_adjust.py
+++ b/metaseq/colormap_adjust.py
@@ -61,7 +61,7 @@ def smart_colormap(vmin, vmax, color_high='#b11902', hue_low=0.6):
     new_rgb = colorsys.hsv_to_rgb(*hsv)
     new_hex = matplotlib.colors.rgb2hex(new_rgb)
 
-    zeropoint = -vmin / (vmax - vmin)
+    zeropoint = abs(-vmin / (vmax - vmin))
 
     # Create a new colormap using the new hue-shifted color as the low end
     new_cmap = matplotlib.colors.LinearSegmentedColormap.from_list(


### PR DESCRIPTION
When generating a smart_colormap, if vmin is positive, zeropoint become negative. This cascades into generating the new cmap from a list containing the following values:
[0, <0, 1]
This list being unordered causes an exception when trying to save the figure:

File "/opt/anaconda21/lib/python2.7/site-packages/matplotlib/colors.py", line 731, in _init
    self.N, self._segmentdata['red'], self._gamma)
  File "/opt/anaconda21/lib/python2.7/site-packages/matplotlib/colors.py", line 471, in makeMappingArray
    "data mapping points must have x in increasing order")
ValueError: data mapping points must have x in increasing order

This commit just changes zeropoint to it's absolute value, ensuring that it is contained between 0 and 1