### PR TITLE
Make it functional with python3

### DIFF
--- a/metaseq/__init__.py
+++ b/metaseq/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import time
-import helpers
+from  metaseq import helpers
 from metaseq.helpers import data_dir, example_filename
 from metaseq._genomic_signal import genomic_signal
 from metaseq import plotutils

--- a/metaseq/__init__.py
+++ b/metaseq/__init__.py
@@ -2,13 +2,13 @@ import os
 import sys
 import time
 import helpers
-from helpers import data_dir, example_filename
-from _genomic_signal import genomic_signal
-import plotutils
-import integration
-import integration.chipseq
-import colormap_adjust
-import results_table
-import tableprinter
-from version import __version__
-import persistence
+from metaseq.helpers import data_dir, example_filename
+from metaseq._genomic_signal import genomic_signal
+from metaseq import plotutils
+from metaseq import integration
+from metaseq.integration import chipseq
+from metaseq import colormap_adjust
+from metaseq import results_table
+from metaseq import tableprinter
+from metaseq.version import __version__
+from metaseq import persistence

--- a/metaseq/_genomic_signal.py
+++ b/metaseq/_genomic_signal.py
@@ -29,15 +29,15 @@ import sys
 import subprocess
 
 import numpy as np
-from bx.bbi.bigwig_file import BigWigFile
+# from bx.bbi.bigwig_file import BigWigFile
 
-import pybedtools
+# import pybedtools
 
-from array_helpers import _array, _array_parallel, _local_coverage, \
+from metaseq.array_helpers import _array, _array_parallel, _local_coverage, \
     _local_count, _count_array, _count_array_parallel
-import filetype_adapters
-import helpers
-from helpers import rebin
+from  metaseq import filetype_adapters
+# import metaseq.helpers
+from metaseq.helpers import rebin
 
 
 def supported_formats():
@@ -144,7 +144,7 @@ class BaseSignal(object):
 
         # since if we got here processes is not None, then this will trigger
         # a parallel array creation
-        features = helpers.tointerval(features)
+        features = tointerval(features)
         x = np.arange(features.start, features.stop)
         features = list(helpers.split_feature(features, processes))
         ys = self.array(

--- a/metaseq/array_helpers.py
+++ b/metaseq/array_helpers.py
@@ -417,6 +417,14 @@ def _array_parallel(fn, cls, genelist, chunksize=250, processes=1, **kwargs):
             chunks,
             itertools.repeat(kwargs)))
 
+    # results = map(
+    #     _array_star,
+    #     zip(
+    #         itertools.repeat(fn),
+    #         itertools.repeat(cls),
+    #         chunks,
+    #         itertools.repeat(kwargs)))
+
     pool.close()
     pool.join()
     return results
@@ -475,7 +483,17 @@ def _array(fn, cls, genelist, **kwargs):
     for gene in genelist:
         if not isinstance(gene, (list, tuple)):
             gene = [gene]
-        coverage_x, coverage_y = _local_coverage_func(
-            reader, gene, **kwargs)
+
+        try:
+            coverage_x, coverage_y = _local_coverage_func(
+                reader,
+                gene,
+                **kwargs)
+
+        except Exception as e:
+            print("Exception with locus {1}: {0}. skipping...".format(
+                e, gene))
+            coverage_y = np.zeros(shape=kwargs['bins'])
+
         biglist.append(coverage_y)
     return biglist

--- a/metaseq/helpers.py
+++ b/metaseq/helpers.py
@@ -24,7 +24,7 @@ def chunker(f, n):
     while 1:
         if len(x) < n:
             try:
-                x.append(f.next())
+                x.append(next(f))
             except StopIteration:
                 if len(x) > 0:
                     yield tuple(x)
@@ -94,7 +94,7 @@ def tointerval(s):
     """
     If string, then convert to an interval; otherwise just return the input
     """
-    if isinstance(s, basestring):
+    if isinstance(s, str):
         m = coord_re.search(s)
         if m.group('strand'):
             return pybedtools.create_interval_from_list([

--- a/metaseq/integration/chipseq.py
+++ b/metaseq/integration/chipseq.py
@@ -2,7 +2,6 @@
 This module integrates parts of metaseq that are useful for ChIP-seq analysis.
 """
 import os
-from itertools import izip
 import gffutils
 from gffutils.helpers import asinterval
 import metaseq
@@ -12,6 +11,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib
 import yaml
+
 
 def save(c, prefix, relative_paths=True):
     """
@@ -285,11 +285,11 @@ class Chipseq(object):
         limit = 5
         browser = True
         if len(event.ind) > limit:
-            print "more than %s genes selected; not spawning browsers" % limit
+            print("more than %s genes selected; not spawning browsers" % limit)
             browser = False
         for i in event.ind:
             feature = artist.features[ind[i]]
-            print feature,
+            print(feature,)
             if browser:
                 self.minibrowser.plot(feature)
 
@@ -398,7 +398,7 @@ def estimate_shift(signal, genome=None, windowsize=5000, thresh=None,
             "Running cross-correlation on %s regions that passed "
             "threshold\n" % sum(enough))
     results = np.zeros((sum(enough), 2 * maxlag + 1))
-    for i, xy in enumerate(izip(plus[enough], minus[enough])):
+    for i, xy in enumerate(zip(plus[enough], minus[enough])):
         x, y = xy
         results[i] = xcorr(x, y, maxlag)
 
@@ -435,7 +435,7 @@ if __name__ == "__main__":
     try:
         examples = sys.argv[1:]
     except IndexError:
-        print 'Choices are: ', choices
+        print('Choices are: ', choices)
         examples = []
 
     for ex in examples:

--- a/metaseq/minibrowser.py
+++ b/metaseq/minibrowser.py
@@ -57,7 +57,7 @@ from gffutils.helpers import asinterval
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib.gridspec as gridspec
 from matplotlib.ticker import FormatStrFormatter
-import _genomic_signal
+from metaseq import _genomic_signal
 
 
 class BaseMiniBrowser(object):
@@ -185,7 +185,7 @@ class ChIPSeqMiniBrowser(BaseMiniBrowser):
         self.local_coverage_kwargs = local_coverage_kwargs or {}
         self.ip = ip
         self.control = control
-        if isinstance(db, basestring):
+        if isinstance(db, str):
             db = gffutils.FeatureDB(db)
         self.db = db
         self.ip_style = ip_style or {}

--- a/metaseq/persistence.py
+++ b/metaseq/persistence.py
@@ -67,10 +67,10 @@ def save_features_and_arrays(features, arrays, prefix, compressed=False,
 
     if link_features:
         if isinstance(features, pybedtools.BedTool):
-            assert isinstance(features.fn, basestring)
+            assert isinstance(features.fn, str)
             features_filename = features.fn
         else:
-            assert isinstance(features, basestring)
+            assert isinstance(features, str)
             features_filename = features
 
         if overwrite:

--- a/metaseq/plotutils.py
+++ b/metaseq/plotutils.py
@@ -144,11 +144,11 @@ def imshow(arr, x=None, ax=None, vmin=None, vmax=None, percentile=True,
         if vmin is None:
             vmin = arr.min()
         else:
-            vmin = mlab.prctile(arr.ravel(), vmin)
+            vmin = np.percentile(arr.ravel(), vmin)
         if vmax is None:
             vmax = arr.max()
         else:
-            vmax = mlab.prctile(arr.ravel(), vmax)
+            vmax = np.percentile(arr.ravel(), vmax)
     else:
         if vmin is None:
             vmin = arr.min()
@@ -304,9 +304,9 @@ def calculate_limits(array_dict, method='global', percentiles=None, limit=()):
             [i.ravel() for i in array_dict.itervalues()]
         )
         if percentiles:
-            vmin = mlab.prctile(
+            vmin = np.percentile(
                 all_arrays, percentiles[0])
-            vmax = mlab.prctile(
+            vmax = np.percentile(
                 all_arrays, percentiles[1])
 
         else:
@@ -326,9 +326,9 @@ def calculate_limits(array_dict, method='global', percentiles=None, limit=()):
             keys = list(keys)
             all_arrays = np.concatenate([array_dict[i] for i in keys])
             if percentiles:
-                vmin = mlab.prctile(
+                vmin = np.percentile(
                     all_arrays, percentiles[0])
-                vmax = mlab.prctile(
+                vmax = np.percentile(
                     all_arrays, percentiles[1])
             else:
                 vmin = all_arrays.min()
@@ -816,16 +816,16 @@ def input_ip_plots(iparr, inputarr, diffed, x, sort_ind,
     all_base = np.column_stack((iparr.ravel(), inputarr.ravel())).ravel()
 
     if limits1[0] is None:
-        limits1[0] = mlab.prctile(
+        limits1[0] = np.percentile(
             all_base, 1. / all_base.size)
     if limits1[1] is None:
-        limits1[1] = mlab.prctile(
+        limits1[1] = np.percentile(
             all_base, 100 - 1. / all_base.size)
     if limits2[0] is None:
-        limits2[0] = mlab.prctile(
+        limits2[0] = np.percentile(
             diffed.ravel(), 1. / all_base.size)
     if limits2[1] is None:
-        limits2[1] = mlab.prctile(
+        limits2[1] = np.percentile(
             diffed.ravel(), 100 - 1. / all_base.size)
 
     del all_base

--- a/metaseq/plotutils.py
+++ b/metaseq/plotutils.py
@@ -9,7 +9,7 @@ import numpy as np
 from matplotlib.ticker import MaxNLocator
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib import gridspec
-import colormap_adjust
+from metaseq import colormap_adjust
 from scipy import stats
 
 

--- a/metaseq/results_table.py
+++ b/metaseq/results_table.py
@@ -6,7 +6,7 @@ from matplotlib import pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib.patches as patches
 import matplotlib
-import plotutils
+from metaseq import plotutils
 from matplotlib.transforms import blended_transform_factory
 from matplotlib.collections import EventCollection
 import gffutils
@@ -41,7 +41,7 @@ class ResultsTable(object):
         Wrapper around a pandas.DataFrame that adds additional functionality.
         """)
     def __init__(self, data, db=None, import_kwargs=None):
-        if isinstance(data, basestring):
+        if isinstance(data, str):
             import_kwargs = import_kwargs or {}
             data = pandas.read_table(data, **import_kwargs)
         if not isinstance(data, pandas.DataFrame):
@@ -58,7 +58,7 @@ class ResultsTable(object):
         return getattr(self.data, attr)
 
     def __getitem__(self, attr):
-        if isinstance(attr, basestring):
+        if isinstance(attr, str):
             return self.data.__getitem__(attr)
         else:
             return self.__class__(self.data.__getitem__(attr), **self._kwargs)
@@ -97,7 +97,7 @@ class ResultsTable(object):
         db : gffutils.FeatureDB
         """
         if db is not None:
-            if isinstance(db, basestring):
+            if isinstance(db, str):
                 db = gffutils.FeatureDB(db)
             if not isinstance(db, gffutils.FeatureDB):
                 raise ValueError(
@@ -666,7 +666,7 @@ class ResultsTable(object):
             yield _id
 
     def _default_callback(self, i):
-        print self.data.ix[i]
+        print(self.data.ix[i])
 
     def strip_unknown_features(self):
         """
@@ -774,7 +774,7 @@ class DifferentialExpressionResults(ResultsTable):
 
     def __init__(self, data, db=None, header_check=True, **kwargs):
         import_kwargs = kwargs.pop('import_kwargs', {})
-        if header_check and isinstance(data, basestring):
+        if header_check and isinstance(data, str):
             comment_char = import_kwargs.get('comment', '#')
             for i, line in enumerate(open(data)):
                 if line[0] != comment_char:

--- a/metaseq/scripts/metaseq-cli
+++ b/metaseq/scripts/metaseq-cli
@@ -121,5 +121,3 @@ if args.plot:
         plt.ylabel('Features')
         plt.colorbar()
         plt.show()
-
-

--- a/metaseq/tableprinter.py
+++ b/metaseq/tableprinter.py
@@ -137,15 +137,13 @@ def table_maker(subset, ind1, ind2, row_labels, col_labels, title):
         sum(subset & ~ind1 & ind2),
         sum(subset & ~ind1 & ~ind2)
     ]
-    print
-    print title
-    print '-' * len(title)
-    print print_2x2_table(table, row_labels=row_labels, col_labels=col_labels)
-    print print_row_perc_table(
-        table, row_labels=row_labels, col_labels=col_labels)
-    print print_col_perc_table(
-        table, row_labels=row_labels, col_labels=col_labels)
-    print fisher.pvalue(*table)
+    print('\n')
+    print(title)
+    print('-' * len(title))
+    print(print_2x2_table(table, row_labels=row_labels, col_labels=col_labels))
+    print(print_row_perc_table(table, row_labels=row_labels, col_labels=col_labels))
+    print(print_col_perc_table(table, row_labels=row_labels, col_labels=col_labels))
+    print(fisher.pvalue(*table))
 
 
 if __name__ == "__main__":
@@ -169,5 +167,5 @@ if __name__ == "__main__":
     # For the test, remove the first newline and all common leading whitespace
     from textwrap import dedent
     str_table = "".join(str_table.splitlines(True)[1:])
-    print s
+    print(s)
     assert dedent(str_table) == s

--- a/metaseq/test/examples/compare_coverage_bed.py
+++ b/metaseq/test/examples/compare_coverage_bed.py
@@ -33,7 +33,7 @@ if not os.path.exists(bam_fn):
 
 
 # Construct 10kb windows, but subset to only use chr19 (to speed up the test)
-print 'creating windows...'
+print('creating windows...')
 sys.stdout.flush()
 windows = pybedtools.BedTool()\
         .window_maker(genome='hg19', w=10000)\
@@ -46,7 +46,7 @@ def run_bedtools():
     # set up a BAM-based BedTool
     bt = pybedtools.BedTool(bam_fn)
 
-    print 'pybedtools coverageBed starting...',
+    print('pybedtools coverageBed starting...',)
     sys.stdout.flush()
     t0 = time.time()
 
@@ -55,7 +55,7 @@ def run_bedtools():
     bt_array = np.array([i[-1] for i in bt_result], dtype=int)
 
     t1 = time.time()
-    print 'completed in %.2fs' % (t1 - t0)
+    print('completed in %.2fs' % (t1 - t0))
     sys.stdout.flush()
     return bt_array
 
@@ -66,7 +66,7 @@ def run_metaseq():
             metaseq.example_filename('wgEncodeUwTfbsK562CtcfStdAlnRep1.bam'),
             kind='bam')
 
-    print 'metaseq starting...',
+    print('metaseq starting...',)
     sys.stdout.flush()
     t0 = time.time()
 
@@ -79,7 +79,7 @@ def run_metaseq():
             windows, processes=PROCESSES, chunksize=CHUNKSIZE, bins=1)
 
     t1 = time.time()
-    print 'completed in %.2fs' % (t1 - t0)
+    print('completed in %.2fs' % (t1 - t0))
     sys.stdout.flush()
     return ms_array.ravel()
 
@@ -112,8 +112,8 @@ if __name__ == "__main__":
     fig2.subplots_adjust(bottom=0.2)
 
     # Table of differences
-    print 'bin\tcount'
+    print('bin\tcount')
     for cnt, bn in zip(counts[::-1], bins[::-1]):
-        print '%s\t%s' % (bn, cnt)
+        print('%s\t%s' % (bn, cnt))
 
     plt.show()

--- a/metaseq/test/old.test
+++ b/metaseq/test/old.test
@@ -36,7 +36,7 @@ class ResultsTable_features_test(object):
         d = self.d[0]
         assert self.d.id[0] == d.id[0]
         d.id[0] = 'asdf'
-        print d.id
+        print(d.id)
         assert d.id[0] == 'asdf'
         assert d.id[0] != self.d.id[0]
 
@@ -54,7 +54,7 @@ class ResultsTable_features_test(object):
         ind = d.enriched()
         enriched = d[ind]
 
-        print enriched.padj
+        print(enriched.padj)
         assert np.all(enriched.padj < 0.05)
         #assert sum(enriched.padj == 0.05) == 1
         assert not np.any(enriched.padj > 0.05)
@@ -83,7 +83,7 @@ class GenomicSignal_local_count_test(object):
         self.m = metaseq.genomic_signal(
                 metaseq.example_filename('gdc.bam'), kind='bam')
         line = '[%s] %s\n' % (datetime.datetime.now(), self.__class__.__name__)
-        print line
+        print(line)
         sys.stdout.flush()
 
     def teardown(self):
@@ -116,7 +116,7 @@ class GenomicSignal_local_coverage_test(object):
         self.m = metaseq.genomic_signal(
                 metaseq.example_filename('gdc.bam'), kind='bam')
         line = '[%s] %s\n' % (datetime.datetime.now(), self.__class__.__name__)
-        print line
+        print(line)
         sys.stdout.flush()
         pass
 
@@ -556,7 +556,7 @@ class GenomicSignal_array_test(object):
                 (200, 220)]
         features = [pybedtools.Interval('chr2L', *i) for i in features]
         arr = self.m.array(features, bins=20, fragment_size=5)
-        print arr
+        print(arr)
         assert np.all(arr == np.array(
                 [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0],
@@ -586,13 +586,13 @@ class GenomicSignal_array_test(object):
 
         # use more features and test for identity again
         features *= 1000
-        print len(features)
+        print(len(features))
         arr0 = self.m.array(features, bins=20, fragment_size=5)
         arr1 = self.m.array(
                 features, bins=20, fragment_size=5, chunksize=5, processes=PROCESSES)
-        print arr0.shape
-        print arr1.shape
-        print (arr0 != arr1)
+        print(arr0.shape)
+        print(arr1.shape)
+        print(arr0 != arr1)
         assert np.all(arr0 == arr1)
 
 
@@ -616,4 +616,3 @@ class GenomicSignal_bigBed_array_test(GenomicSignal_array_test):
     def setup(self):
         self.m = metaseq.genomic_signal(
                 metaseq.example_filename('gdc.bigbed'), kind='bigbed')
-

--- a/metaseq/test/test.py
+++ b/metaseq/test/test.py
@@ -21,9 +21,9 @@ for kind in ['bed', 'bam', 'bigbed', 'bigwig']:
 PROCESSES = int(os.environ.get("METASEQ_PROCESSES", multiprocessing.cpu_count()))
 
 def test_tointerval():
-    assert metaseq.helpers.tointerval("chr2L:1-10[-]").strand == '-'
-    assert metaseq.helpers.tointerval("chr2L:1-10[+]").strand == '+'
-    assert metaseq.helpers.tointerval("chr2L:1-10").strand == '.'
+    assert tointerval("chr2L:1-10[-]").strand == '-'
+    assert tointerval("chr2L:1-10[+]").strand == '+'
+    assert .tointerval("chr2L:1-10").strand == '.'
 
 
 def test_local_count():
@@ -260,7 +260,7 @@ def test_local_coverage_binned():
         try:
             assert np.allclose(result[0], expected[0]) and np.allclose(result[1], expected[1])
         except:
-            print (kind, coord, result, expected)
+            print(kind, coord, result, expected)
             raise
 
     for kind in ['bam', 'bigbed', 'bed', 'bigwig']:
@@ -294,7 +294,7 @@ def test_array_binned():
         try:
             assert np.allclose(result, expected)
         except:
-            print (kind, coord, result, expected)
+            print(kind, coord, result, expected)
             raise
 
     for kind in ['bam', 'bigbed', 'bed', 'bigwig']:
@@ -328,7 +328,7 @@ def test_array_binned_preserve_total():
         try:
             assert np.allclose(result, expected)
         except:
-            print (kind, coord, result, expected)
+            print(kind, coord, result, expected)
             raise
 
     for kind in ['bam', 'bigbed', 'bed', 'bigwig']:
@@ -388,7 +388,7 @@ def test_array_ragged():
                 for i, j in zip(result, expected):
                     assert np.allclose(i, j)
         except:
-            print (kind, coord, result, expected)
+            print(kind, coord, result, expected)
             raise
 
     for kind in ['bam', 'bigbed', 'bed', 'bigwig']:
@@ -466,7 +466,7 @@ def test_nonbigwig_kwargs():
                 ArgumentError, gs['bigwig'].local_coverage, 'chr2L:1-20',
                 **kwargs)
         except AssertionError:
-            print kwargs
+            print(kwargs)
             raise
 
     assert_raises(ArgumentError, gs['bigwig'].local_coverage, 'chr2L:1-20',
@@ -659,4 +659,3 @@ def test_bigwig_zero_inf_nan():
         ),
     ]:
         yield check, coord, kwargs, expected
-

--- a/metaseq/test/test_results_table.py
+++ b/metaseq/test/test_results_table.py
@@ -24,7 +24,7 @@ def test_copy():
 
 def smoke_tests():
     #smoke test for repr
-    print repr(d)
+    print(repr(d))
 
 def test_db():
 


### PR DESCRIPTION
metaseq cannot be installed with python2 anymore because of biopython which is not compatible with python2 anymore.
Moreover, the metaseq dependencies (e.g. import plotutils to import methods from the "plotutils.py" file) are not written correctly (from metaseq import plotutils). This will make the package uninstallable.

This PR is an attempt to fix these issues (not all the functionalities tested) 